### PR TITLE
Add Russian localization and UI improvements

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10,8 +10,46 @@ createApp({
       password: '',
       masked: false,
       countdown: 0,
-      timer: null
+      timer: null,
+      lang: 'ru',
+      translations: {
+        ru: {
+          title: 'Генератор сложных паролей',
+          length: 'Длина пароля:',
+          useDigits: 'Использовать цифры',
+          useSpecial: 'Использовать спецсимволы',
+          excludeSimilar: 'Исключить похожие символы',
+          create: 'Создать пароль',
+          createNew: 'Создать новый пароль',
+          copy: 'Копировать',
+          show: 'Показать',
+          hide: 'Скрыть',
+          visible: 'Виден ещё',
+          seconds: 'сек.',
+          placeholder: 'Пароль'
+        },
+        en: {
+          title: 'Strong Password Generator',
+          length: 'Password length:',
+          useDigits: 'Use digits',
+          useSpecial: 'Use special characters',
+          excludeSimilar: 'Exclude similar characters',
+          create: 'Create Password',
+          createNew: 'Create New Password',
+          copy: 'Copy',
+          show: 'Show',
+          hide: 'Hide',
+          visible: 'Visible for',
+          seconds: 'seconds',
+          placeholder: 'Password'
+        }
+      }
     };
+  },
+  computed: {
+    t() {
+      return this.translations[this.lang];
+    }
   },
   methods: {
     setLength(len) {
@@ -22,7 +60,7 @@ createApp({
       const similar = /[ilLIoO0]/g;
       let chars = letters + letters.toUpperCase();
       if (this.useDigits) chars += '0123456789';
-      if (this.useSpecial) chars += '!@#$%^&*()_+-=[]{}|;:,.<>?';
+      if (this.useSpecial) chars += '!@#$^&*()_+-=[]{}|<>?';
       if (this.excludeSimilar) chars = chars.replace(similar, '');
       let result = '';
       for (let i = 0; i < this.length; i++) {

--- a/public/index.html
+++ b/public/index.html
@@ -1,36 +1,40 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Strong Password Generator</title>
+  <title>Генератор сложных паролей</title>
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js"></script>
 </head>
 <body>
   <div id="app" class="container">
-    <h1><span class="lock">🔒</span> Strong Password Generator</h1>
+    <div class="locale">
+      <button @click="lang='ru'" :class="{active: lang==='ru'}">Русский</button>
+      <button @click="lang='en'" :class="{active: lang==='en'}">English</button>
+    </div>
+    <h1><span class="lock">🔒</span> {{ t.title }}</h1>
     <div class="length">
-      <label>Password length:</label>
-      <button @click="setLength(8)">8</button>
-      <button @click="setLength(10)">10</button>
-      <button @click="setLength(12)">12</button>
-      <button @click="setLength(16)">16</button>
+      <label>{{ t.length }}</label>
+      <button @click="setLength(8)" :class="{active: length===8}">8</button>
+      <button @click="setLength(10)" :class="{active: length===10}">10</button>
+      <button @click="setLength(12)" :class="{active: length===12}">12</button>
+      <button @click="setLength(16)" :class="{active: length===16}">16</button>
     </div>
     <div class="options">
-      <label><input type="checkbox" v-model="useDigits"> Use digits</label>
-      <label><input type="checkbox" v-model="useSpecial"> Use special characters</label>
-      <label><input type="checkbox" v-model="excludeSimilar"> Exclude similar characters</label>
+      <label><input type="checkbox" v-model="useDigits"> {{ t.useDigits }}</label>
+      <label><input type="checkbox" v-model="useSpecial"> {{ t.useSpecial }}</label>
+      <label><input type="checkbox" v-model="excludeSimilar"> {{ t.excludeSimilar }}</label>
     </div>
     <div class="actions">
-      <button @click="generatePassword">Create Password</button>
+      <button @click="generatePassword">{{ t.create }}</button>
     </div>
-    <div v-if="password" class="result">
-      <input :type="masked ? 'password' : 'text'" v-model="password" readonly>
-      <button @click="copyPassword">Copy</button>
-      <button @click="generatePassword">Create New Password</button>
-      <button @click="toggleMask">{{ masked ? 'Show' : 'Hide' }}</button>
-      <div v-if="countdown > 0" class="timer">Visible for {{ countdown }} seconds</div>
+    <div class="result">
+      <input :type="masked ? 'password' : 'text'" v-model="password" readonly :placeholder="t.placeholder"/>
+      <button @click="copyPassword">{{ t.copy }}</button>
+      <button @click="generatePassword">{{ t.createNew }}</button>
+      <button @click="toggleMask">{{ masked ? t.show : t.hide }}</button>
+      <div v-if="countdown > 0" class="timer">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
     </div>
   </div>
   <script src="app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,6 +36,10 @@ h1 {
   margin-bottom: 1em;
 }
 
+.locale {
+  margin-bottom: 1em;
+}
+
 button {
   background: #2c64e3;
   color: #fff;
@@ -49,6 +53,10 @@ button {
 
 button:hover {
   background: #2456c0;
+}
+
+button.active {
+  background: #1b49a5;
 }
 
 .result input {


### PR DESCRIPTION
## Summary
- localize UI with Russian default and English option
- show password field at all times
- highlight selected length and language buttons
- refine allowed special characters

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d6a9a66e483299c7785dae978ae47