### PR TITLE
Improve generator UI layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,25 +11,29 @@
   <div id="app" class="container">
     <button class="locale-toggle" @click="toggleLang">{{ lang === 'ru' ? 'RU' : 'EN' }}</button>
     <h1><span class="lock">🔒</span> {{ t.title }}</h1>
-    <div class="length">
-      <label>{{ t.length }}</label>
-      <button @click="setLength(8)" :class="{active: length===8}">8</button>
-      <button @click="setLength(10)" :class="{active: length===10}">10</button>
-      <button @click="setLength(12)" :class="{active: length===12}">12</button>
-      <button @click="setLength(16)" :class="{active: length===16}">16</button>
-    </div>
-    <div class="options">
-      <label><input type="checkbox" v-model="useDigits"> {{ t.useDigits }}</label>
-      <label><input type="checkbox" v-model="useSpecial"> {{ t.useSpecial }}</label>
-      <label><input type="checkbox" v-model="excludeSimilar"> {{ t.excludeSimilar }}</label>
+    <div class="settings">
+      <div class="length">
+        <label>{{ t.length }}</label>
+        <button @click="setLength(8)" :class="{active: length===8}">8</button>
+        <button @click="setLength(10)" :class="{active: length===10}">10</button>
+        <button @click="setLength(12)" :class="{active: length===12}">12</button>
+        <button @click="setLength(16)" :class="{active: length===16}">16</button>
+      </div>
+      <div class="options">
+        <label><input type="checkbox" v-model="useDigits"> {{ t.useDigits }}</label>
+        <label><input type="checkbox" v-model="useSpecial"> {{ t.useSpecial }}</label>
+        <label><input type="checkbox" v-model="excludeSimilar"> {{ t.excludeSimilar }}</label>
+      </div>
     </div>
     <div class="actions">
       <button @click="generatePassword">{{ t.create }}</button>
     </div>
     <div class="result">
-      <input :type="masked ? 'password' : 'text'" v-model="password" readonly :placeholder="t.placeholder"/>
+      <div class="password-wrapper">
+        <input :type="masked ? 'password' : 'text'" v-model="password" readonly :placeholder="t.placeholder" />
+        <button class="toggle-eye" @click="toggleMask">👁</button>
+      </div>
       <button @click="copyPassword">{{ t.copy }}</button>
-      <button @click="toggleMask">{{ masked ? t.show : t.hide }}</button>
       <div v-if="countdown > 0" class="timer">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
     </div>
   </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -21,7 +21,7 @@ body {
 }
 
 h1 {
-  margin-top: 0;
+  margin-top: 4em;
   margin-bottom: 1em;
   color: #2c64e3;
   font-weight: 500;
@@ -42,6 +42,13 @@ h1 {
   padding: 0.8em 1.2em;
 }
 
+.settings {
+  border: 1px solid #ccc;
+  padding: 1em;
+  border-radius: 4px;
+  margin-bottom: 1em;
+}
+
 .options label {
   display: block;
   margin: 0.25em 0;
@@ -52,6 +59,8 @@ h1 {
   position: absolute;
   top: 1em;
   right: 1em;
+  font-size: 0.5em;
+  padding: 0.3em 0.5em;
 }
 
 button {
@@ -74,12 +83,31 @@ button.active {
   color: #fff;
 }
 
-.result input {
+.password-wrapper {
+  position: relative;
   width: 100%;
-  padding: 0.5em;
+}
+
+.password-wrapper input {
+  width: 100%;
+  padding: 1em;
+  padding-right: 2.5em;
   border: 1px solid #ccc;
   border-radius: 4px;
   margin-bottom: 0.5em;
+  font-size: 2em;
+  text-align: center;
+}
+
+.toggle-eye {
+  position: absolute;
+  right: 0.5em;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
 }
 
 .timer {


### PR DESCRIPTION
## Summary
- expand spacing above the header
- shrink language toggle button
- group length and option controls into a settings block
- enlarge password field and center its text
- replace the show button with an eye icon positioned inside the field

## Testing
- `npm test` *(fails: Missing script)*
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_684d6faf135483299a75866e74c88269