### PR TITLE
Improve password visibility flow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -86,7 +86,10 @@ createApp({
     },
     toggleMask() {
       this.masked = !this.masked;
-      if (!this.masked && this.countdown === 0) {
+      if (this.masked) {
+        clearInterval(this.timer);
+        this.countdown = 0;
+      } else {
         this.restartTimer();
       }
     },

--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
         <button class="toggle-eye" @click="toggleMask">👁</button>
       </div>
       <button @click="copyPassword">{{ t.copy }}</button>
-      <div v-if="countdown > 0" class="timer">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
+      <div v-if="!masked && countdown > 0" class="timer">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
     </div>
   </div>
   <script src="app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -85,8 +85,8 @@ button.active {
 
 .password-wrapper {
   position: relative;
-  width: 50%;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
 }
 
 .password-wrapper input {


### PR DESCRIPTION
## Summary
- tweak password visibility toggle so timer hides when password is hidden
- restart visibility timer whenever the password is shown again
- make password input stretch full width

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684d724bb3488329a3a4d5e09c1ad103