### PR TITLE
Fix password field overflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
         <button class="toggle-eye" @click="toggleMask">👁</button>
       </div>
       <button @click="copyPassword">{{ t.copy }}</button>
-      <div v-if="!masked && countdown > 0" class="timer">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
+      <div class="timer" :class="{ hidden: masked || countdown === 0 }">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
     </div>
   </div>
   <script src="app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -85,12 +85,13 @@ button.active {
 
 .password-wrapper {
   position: relative;
-  width: 80%;
+  width: 100%;
   margin: 0;
 }
 
 .password-wrapper input {
-  width: 80%;
+  width: 100%;
+  box-sizing: border-box;
   padding: 1em;
   padding-right: 2.5em;
   border: 1px solid #ccc;
@@ -115,4 +116,9 @@ button.active {
   margin-top: 0.5em;
   font-size: 0.9em;
   color: #555;
+  min-height: 1.2em;
+}
+
+.timer.hidden {
+  visibility: hidden;
 }


### PR DESCRIPTION
## Summary
- prevent password input from exceeding container width by using `box-sizing: border-box`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857fb2e8648832998bd9c0283d0b671