### PR TITLE
Fix password input overflow

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -90,6 +90,7 @@ button.active {
 }
 
 .password-wrapper input {
+  box-sizing: border-box;
   width: 100%;
   padding: 1em;
   padding-right: 2.5em;


### PR DESCRIPTION
## Summary
- prevent password input from exceeding container width

## Testing
- `node index.js &>/tmp/app.log &`

------
https://chatgpt.com/codex/tasks/task_e_68580fdc86a083299c003a392e0c6da0