### PR TITLE
Add placeholder color for password input

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -101,6 +101,10 @@ button.active {
   text-align: center;
 }
 
+.password-wrapper input::placeholder {
+  color: #666666;
+}
+
 .toggle-eye {
   position: absolute;
   right: 0.5em;


### PR DESCRIPTION
## Summary
- style input placeholders with higher contrast

## Testing
- `node` script to calculate contrast ratios

------
https://chatgpt.com/codex/tasks/task_e_687547094d7083299222db5a54de7068