### PR TITLE
Fix tap targets on mobile

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -126,3 +126,19 @@ button.active {
 .timer.hidden {
   visibility: hidden;
 }
+@media (pointer: coarse) {
+  .length button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+  .options label {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+  }
+  .options input[type="checkbox"] {
+    width: 24px;
+    height: 24px;
+    margin-right: 0.5em;
+  }
+}


### PR DESCRIPTION
## Summary
- improve size of length buttons and option checkboxes on touch devices

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6875483e33c483299ca85c69acdad5de