### PR TITLE
Add copy confirmation toast

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -11,6 +11,7 @@ createApp({
       masked: false,
       countdown: 0,
       timer: null,
+      copied: false,
       lang: 'ru',
       translations: {
         ru: {
@@ -21,6 +22,7 @@ createApp({
           excludeSimilar: 'Исключить похожие символы',
           create: 'Создать пароль',
           copy: 'Копировать',
+          copied: 'Скопировано!',
           show: 'Показать',
           hide: 'Скрыть',
           visible: 'Виден ещё',
@@ -36,6 +38,7 @@ createApp({
           excludeSimilar: 'Exclude similar characters',
           create: 'Create Password',
           copy: 'Copy',
+          copied: 'Copied!',
           show: 'Show',
           hide: 'Hide',
           visible: 'Visible for',
@@ -101,7 +104,12 @@ createApp({
       }, 1000);
     },
     copyPassword() {
-      navigator.clipboard.writeText(this.password);
+      navigator.clipboard.writeText(this.password).then(() => {
+        this.copied = true;
+        setTimeout(() => {
+          this.copied = false;
+        }, 1500);
+      });
     },
     toggleMask() {
       this.masked = !this.masked;

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,7 @@
       </div>
       <button @click="copyPassword">{{ t.copy }}</button>
       <div class="timer" :class="{ hidden: masked || countdown === 0 }">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
+      <div class="copy-toast" v-if="copied">{{ t.copied }}</div>
     </div>
   </div>
   <script src="app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -170,3 +170,24 @@ button.active {
   font-size: 0.9em;
   color: #555;
 }
+
+.copy-toast {
+  position: absolute;
+  left: 50%;
+  bottom: 1em;
+  transform: translateX(-50%);
+  background: #2ecc71;
+  color: #fff;
+  padding: 0.5em 1em;
+  border-radius: 4px;
+  animation: fadeout 1.5s forwards;
+  pointer-events: none;
+  font-size: 0.9em;
+}
+
+@keyframes fadeout {
+  0% { opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- show copy confirmation after clicking **Copy**
- add translations for the message
- style toast and inject into the page

## Testing
- `npm start --silent`

------
https://chatgpt.com/codex/tasks/task_e_6875527e7864832981d3e21f25c10736