### PR TITLE
Improve generator defaults and add localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Strong Password Generator
 
-A simple one-page password generator.
+A simple one-page password generator with multiple language support (Russian, English, Spanish and Chinese).
 
 ## Usage
 
@@ -9,3 +9,5 @@ node index.js
 ```
 
 Open `http://localhost:3000` in your browser.
+
+The password is generated locally in your browser and is never sent to the server.

--- a/public/app.js
+++ b/public/app.js
@@ -3,16 +3,18 @@ const { createApp } = Vue;
 createApp({
   data() {
     return {
-      length: 8,
+      length: 12,
       useDigits: true,
-      useSpecial: false,
-      excludeSimilar: false,
+      useSpecial: true,
+      excludeSimilar: true,
       password: '',
       masked: false,
       countdown: 0,
       timer: null,
       copied: false,
       lang: 'ru',
+      langs: ['ru','en','es','zh'],
+      profile: '',
       translations: {
         ru: {
           title: 'Генератор сложных паролей',
@@ -28,6 +30,17 @@ createApp({
           visible: 'Виден ещё',
           seconds: 'сек.',
           placeholder: 'Пароль',
+          localNote: 'Пароль генерируется локально, мы его не сохраняем',
+          tipsTitle: 'Советы',
+          tip1: 'Как придумать и запомнить пароль',
+          tip2: 'Зачем использовать менеджер паролей',
+          profile: 'Профиль:',
+          profileSocial: 'Соцсети',
+          profileBank: 'Банк',
+          profileGov: 'Госуслуги',
+          profileEmail: 'Почта',
+          github: 'Код на GitHub',
+          privacy: 'Политика конфиденциальности',
           strengths: ['Очень слабый', 'Слабый', 'Нормальный', 'Хороший', 'Отличный']
         },
         en: {
@@ -44,7 +57,72 @@ createApp({
           visible: 'Visible for',
           seconds: 'seconds',
           placeholder: 'Password',
+          localNote: 'Password is generated locally, we do not save it',
+          tipsTitle: 'Tips',
+          tip1: 'How to create and remember a password',
+          tip2: 'Why use a password manager',
+          profile: 'Profile:',
+          profileSocial: 'Social',
+          profileBank: 'Bank',
+          profileGov: 'Government',
+          profileEmail: 'Email',
+          github: 'GitHub source',
+          privacy: 'Privacy policy',
           strengths: ['Very Weak', 'Weak', 'Normal', 'Good', 'Excellent']
+        },
+        es: {
+          title: 'Generador de contraseñas seguras',
+          length: 'Longitud de la contraseña:',
+          useDigits: 'Usar dígitos',
+          useSpecial: 'Usar caracteres especiales',
+          excludeSimilar: 'Excluir caracteres similares',
+          create: 'Crear contraseña',
+          copy: 'Copiar',
+          copied: '¡Copiado!',
+          show: 'Mostrar',
+          hide: 'Ocultar',
+          visible: 'Visible por',
+          seconds: 'seg.',
+          placeholder: 'Contraseña',
+          localNote: 'La contraseña se genera localmente, no la guardamos',
+          tipsTitle: 'Consejos',
+          tip1: 'Cómo crear y recordar una contraseña',
+          tip2: 'Por qué usar un gestor de contraseñas',
+          profile: 'Perfil:',
+          profileSocial: 'Redes sociales',
+          profileBank: 'Banco',
+          profileGov: 'Servicios públicos',
+          profileEmail: 'Correo',
+          github: 'Código en GitHub',
+          privacy: 'Política de privacidad',
+          strengths: ['Muy débil', 'Débil', 'Normal', 'Buena', 'Excelente']
+        },
+        zh: {
+          title: '强密码生成器',
+          length: '密码长度:',
+          useDigits: '使用数字',
+          useSpecial: '使用特殊字符',
+          excludeSimilar: '排除相似字符',
+          create: '生成密码',
+          copy: '复制',
+          copied: '已复制',
+          show: '显示',
+          hide: '隐藏',
+          visible: '可见',
+          seconds: '秒',
+          placeholder: '密码',
+          localNote: '密码在本地生成，我们不保存',
+          tipsTitle: '提示',
+          tip1: '如何创建并记住密码',
+          tip2: '为什么使用密码管理器',
+          profile: '配置:',
+          profileSocial: '社交',
+          profileBank: '银行',
+          profileGov: '政府',
+          profileEmail: '邮箱',
+          github: 'GitHub 代码',
+          privacy: '隐私政策',
+          strengths: ['弱', '轻弱', '一般', '好', '优秀']
         }
       }
     };
@@ -74,6 +152,21 @@ createApp({
   methods: {
     setLength(len) {
       this.length = len;
+    },
+    applyProfile() {
+      const map = {
+        social: { length: 12, digits: true, special: true },
+        bank: { length: 16, digits: true, special: true },
+        gov: { length: 12, digits: true, special: true },
+        email: { length: 10, digits: true, special: false }
+      };
+      const p = map[this.profile];
+      if (p) {
+        this.length = p.length;
+        this.useDigits = p.digits;
+        this.useSpecial = p.special;
+        this.excludeSimilar = true;
+      }
     },
     generatePassword() {
       const letters = 'abcdefghijklmnopqrstuvwxyz';
@@ -121,7 +214,8 @@ createApp({
       }
     },
     toggleLang() {
-      this.lang = this.lang === 'ru' ? 'en' : 'ru';
+      const idx = this.langs.indexOf(this.lang);
+      this.lang = this.langs[(idx + 1) % this.langs.length];
     }
   }
 }).mount('#app');

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div id="app" class="container">
-    <button class="locale-toggle" @click="toggleLang">{{ lang === 'ru' ? 'RU' : 'EN' }}</button>
+    <button class="locale-toggle" @click="toggleLang">{{ lang.toUpperCase() }}</button>
     <h1><span class="lock">🔒</span> {{ t.title }}</h1>
     <div class="settings">
       <div class="length">
@@ -20,14 +20,26 @@
         <button @click="setLength(12)" :class="{active: length===12}">12</button>
         <button @click="setLength(16)" :class="{active: length===16}">16</button>
       </div>
+      <div class="profile">
+        <label>{{ t.profile }}
+          <select v-model="profile" @change="applyProfile">
+            <option value=""></option>
+            <option value="social">{{ t.profileSocial }}</option>
+            <option value="bank">{{ t.profileBank }}</option>
+            <option value="gov">{{ t.profileGov }}</option>
+            <option value="email">{{ t.profileEmail }}</option>
+          </select>
+        </label>
+      </div>
       <div class="options">
-        <label><input type="checkbox" v-model="useDigits"> {{ t.useDigits }}</label>
-        <label><input type="checkbox" v-model="useSpecial"> {{ t.useSpecial }}</label>
-        <label><input type="checkbox" v-model="excludeSimilar"> {{ t.excludeSimilar }}</label>
+        <label for="digits"><input id="digits" type="checkbox" v-model="useDigits"> {{ t.useDigits }}</label>
+        <label for="special"><input id="special" type="checkbox" v-model="useSpecial"> {{ t.useSpecial }}</label>
+        <label for="similar"><input id="similar" type="checkbox" v-model="excludeSimilar"> {{ t.excludeSimilar }}</label>
       </div>
     </div>
     <div class="actions">
       <button @click="generatePassword">{{ t.create }}</button>
+      <div class="note">{{ t.localNote }}</div>
     </div>
     <div class="result">
       <div class="password-wrapper">
@@ -47,6 +59,18 @@
       <div class="timer" :class="{ hidden: masked || countdown === 0 }">{{ t.visible }} {{ countdown }} {{ t.seconds }}</div>
       <div class="copy-toast" v-if="copied">{{ t.copied }}</div>
     </div>
+    <div class="tips">
+      <h2>{{ t.tipsTitle }}</h2>
+      <ul>
+        <li><a href="https://www.wikihow.com/Make-a-Strong-Password" target="_blank">{{ t.tip1 }}</a></li>
+        <li><a href="https://support.apple.com/HT201303" target="_blank">{{ t.tip2 }}</a></li>
+      </ul>
+    </div>
+    <footer>
+      <a href="https://github.com/example/strongpassword" target="_blank">{{ t.github }}</a>
+      |
+      <a href="privacy.html" target="_blank">{{ t.privacy }}</a>
+    </footer>
   </div>
   <script src="app.js"></script>
 </body>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Privacy Policy</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Privacy Policy</h1>
+    <p>This password generator works entirely in your browser. We do not collect or store any generated passwords.</p>
+  </div>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -33,7 +33,8 @@ h1 {
 
 .length,
 .options,
-.actions {
+.actions,
+.profile {
   margin-bottom: 1em;
 }
 
@@ -183,6 +184,36 @@ button.active {
   animation: fadeout 1.5s forwards;
   pointer-events: none;
   font-size: 0.9em;
+}
+
+.note {
+  margin-top: 0.5em;
+  font-size: 0.9em;
+  color: #555;
+}
+
+.tips {
+  margin-top: 1em;
+  text-align: left;
+}
+
+.tips h2 {
+  margin-bottom: 0.5em;
+}
+
+.tips ul {
+  padding-left: 1em;
+}
+
+footer {
+  margin-top: 1em;
+  font-size: 0.9em;
+}
+
+footer a {
+  color: #2c64e3;
+  text-decoration: none;
+  margin: 0 0.3em;
 }
 
 @keyframes fadeout {


### PR DESCRIPTION
## Summary
- increase default password length and enable special characters
- add Spanish and Chinese translations
- implement profile presets and tips section
- note that generation is local
- add links to GitHub and a privacy policy

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687555aeafe48329b6e8915bed79ddf0