### PR TITLE
Improve language switcher and default profile

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -14,7 +14,7 @@ createApp({
       copied: false,
       lang: 'ru',
       langs: ['ru','en','es','zh'],
-      profile: '',
+      profile: 'social',
       translations: {
         ru: {
           title: 'Генератор сложных паролей',
@@ -149,6 +149,9 @@ createApp({
       return `strength-${this.strength}`;
     }
   },
+  created() {
+    this.applyProfile();
+  },
   methods: {
     setLength(len) {
       this.length = len;
@@ -213,9 +216,8 @@ createApp({
         this.restartTimer();
       }
     },
-    toggleLang() {
-      const idx = this.langs.indexOf(this.lang);
-      this.lang = this.langs[(idx + 1) % this.langs.length];
+    setLang(l) {
+      this.lang = l;
     }
   }
 }).mount('#app');

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,11 @@
 </head>
 <body>
   <div id="app" class="container">
-    <button class="locale-toggle" @click="toggleLang">{{ lang.toUpperCase() }}</button>
+    <div class="locale-switch">
+      <button v-for="l in langs" :key="l" @click="setLang(l)" :class="{active: lang === l}">
+        {{ l.toUpperCase() }}
+      </button>
+    </div>
     <h1><span class="lock">🔒</span> {{ t.title }}</h1>
     <div class="settings">
       <div class="length">
@@ -23,7 +27,6 @@
       <div class="profile">
         <label>{{ t.profile }}
           <select v-model="profile" @change="applyProfile">
-            <option value=""></option>
             <option value="social">{{ t.profileSocial }}</option>
             <option value="bank">{{ t.profileBank }}</option>
             <option value="gov">{{ t.profileGov }}</option>

--- a/public/styles.css
+++ b/public/styles.css
@@ -56,10 +56,13 @@ h1 {
 }
 
 
-.locale-toggle {
+.locale-switch {
   position: absolute;
   top: 1em;
   right: 1em;
+}
+
+.locale-switch button {
   font-size: 0.5em;
   padding: 0.3em 0.5em;
 }


### PR DESCRIPTION
## Summary
- display all language buttons at the top of the page
- remove empty profile option and select Social by default
- adjust JS to apply default profile and change languages directly
- update styles for new locale switcher

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687559641404832987938fd7648fc856